### PR TITLE
Cocoapods versions updated.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -109,11 +109,11 @@
         <framework src="AMRAdapterAdcolony" type="podspec" spec="~> 4.2" />
         <framework src="AMRAdapterAdmob" type="podspec" spec="~> 7.62" />
         <framework src="AMRAdapterAdmost" type="podspec" spec="~> 1.3" />
-        <framework src="AMRAdapterApplovin" type="podspec" spec="~> 6.13" />
+        <framework src="AMRAdapterApplovin" type="podspec" spec="~> 10.3" />
         <framework src="AMRAdapterChartboost" type="podspec" spec="~> 8.2" />
         <framework src="AMRAdapterDFP" type="podspec" spec="~> 7.62" />
         <framework src="AMRAdapterFacebook" type="podspec" spec="~> 5.9" />
-        <framework src="AMRAdapterIronsource" type="podspec" spec="~> 6.17" />
+        <framework src="AMRAdapterIronsource" type="podspec" spec="~> 7.1" />
         <framework src="AMRAdapterMintegral" type="podspec" spec="~> 6.3" />
         <framework src="AMRAdapterOgury" type="podspec" spec="~> 1.4" />
         <framework src="AMRAdapterTapjoy" type="podspec" spec="~> 12.6" />


### PR DESCRIPTION
Applovin and ironsource podspecs updated.
The current version of pods gives an error due to the deprecation of bintray.